### PR TITLE
Added easy category/tag support

### DIFF
--- a/add-page-by-form.php
+++ b/add-page-by-form.php
@@ -450,15 +450,19 @@ class AddPageByFormPlugin extends Plugin
 
                         $file_fields = $this->moveFiles($form_page_relative_page_path, $parent_page_path, $slug);
 
-                        // Process category and tags
+                        // Process category, tags, and author
                         if($page_frontmatter['category']) {
-                            $page_frontmatter['taxonomy']['category'] = $page_frontmatter['category'];
+                            $cats = str_replace(' ', '-', strtolower($page_frontmatter['category']));
+                            $page_frontmatter['taxonomy']['category'] = $cats;
                             unset($page_frontmatter['category']);
-                        }
 
-                        if($page_frontmatter['tags']){
-                            $page_frontmatter['taxonomy']['tags'] = '['.$page_frontmatter['tags'].']';
+                        if($page_frontmatter['tags']) {
+                            $tags = str_replace(' ', '-', strtolower($page_frontmatter['tags']));
+                            $page_frontmatter['taxonomy']['tags'] = '['.$tags.']';
                             unset($page_frontmatter['tags']);
+
+                        if($page_frontmatter['author']) {
+                            $page_frontmatter['taxonomy']['author'] = '\''.$page_frontmatter['author'].'\'';
                         }
 
                         // Add uploaded file properties to frontmatter

--- a/add-page-by-form.php
+++ b/add-page-by-form.php
@@ -450,6 +450,17 @@ class AddPageByFormPlugin extends Plugin
 
                         $file_fields = $this->moveFiles($form_page_relative_page_path, $parent_page_path, $slug);
 
+                        // Process category and tags
+                        if($page_frontmatter['category']) {
+                            $page_frontmatter['taxonomy']['category'] = $page_frontmatter['category'];
+                            unset($page_frontmatter['category']);
+                        }
+
+                        if($page_frontmatter['tags']){
+                            $page_frontmatter['taxonomy']['tags'] = '['.$page_frontmatter['tags'].']';
+                            unset($page_frontmatter['tags']);
+                        }
+
                         // Add uploaded file properties to frontmatter
                         if (isset($file_fields) && isset($page_frontmatter)) {
                             $page_frontmatter = array_merge($page_frontmatter, $file_fields);


### PR DESCRIPTION
Added easy category and tag support.

In a form page, you can add:
```
form:
    name: addpage-new-article
    fields:
        -
            name: title
            label: Title
            type: text
            validate:
                required: true
        -
            name: content
            label: Content
            type: textarea
            size: long
            classes: editor
            validate:
                required: true
        -
            name: attachments
            label: Attachment
            type: file
            multiple: true
            destination: '@self'
            accept:
                - '*'
            validate:
                required: false
        -
            name: author
            label: Author
            type: text
            validate:
                required: true
        -
            name: category
            label: Category
            type: text
            validate:
                required: true
        -
            name: tags
            label: 'Tags (comma-separated)'
            type: text
            validate:
                required: true
        -
            name: honeypot
            type: honeypot
```

The plugin now automatically adds these to the taxonomy.