### PR TITLE
support multiple slug_fields in comma separated list to form unique slug

### DIFF
--- a/add-page-by-form.php
+++ b/add-page-by-form.php
@@ -562,7 +562,24 @@ class AddPageByFormPlugin extends Plugin
                         }
                         // Create a slug to be used as the page name (used publicly in URLs etc.)
                         if ($slug_field != '') {
-                            if (isset($page_frontmatter[$slug_field])) {
+                            // check if slug_field is comma separate list
+                            if (strpos($slug_field, ',') !== false) {
+                                $slug_field_array = explode(',', $slug_field);
+                                // make sure all slug elements are set
+                                $slugs_set = [];
+                                foreach($slug_field_array as $sf) {
+                                    $slugs_set[] = isset($page_frontmatter[trim($sf)]);
+                                }
+                                // if slug elements are set, build array of values
+                                if ( !empty($slugs_set) && !!array_product($slugs_set)) {
+                                    $slug_elems = [];
+                                    foreach($slug_field_array as $sf) {
+                                        $slug_elems[] = self::slug($page_frontmatter[trim($sf)]);
+                                    }
+                                    $slug = implode('-', $slug_elems);
+                                }
+                            // else if slug_field is single entry, use that
+                            } elseif (isset($page_frontmatter[$slug_field])) { 
                                 $slug = self::slug($page_frontmatter[$slug_field]);
                             }
                         }


### PR DESCRIPTION
This pull request adds support for the use of multiple slug_field entries for creating the slug, for example, in a `form.md` entry
```
pageconfig:
    overwrite_mode: true
    slug_field: date, speaker
```
where `date` and `speaker` are two fields populated in the example `form.md` file.

The code first verifies that all slug_fields are set, and then builds the slug with the entries separated by `-`.

This has been tested on a live GRAV site and verified to work.  

I attempted to use `array_map` to build the `$slugs_set` and `$slug_elems` arrays, rather than the `foreach` loops, as that would have been fewer lines, but I was not able to build the `$slugs_set` array of bools properly.

The use case was when two people might give a talk at the same conference.  Originally, the `date` slug_field was used to create the slug, but the entries from multiple people led to entries being overwritten as they had the same date (the overwrite is set to true such that a member can update their entry with new info).  By using multiple fields for the slug_field, a unique slug can be generated for this use case.